### PR TITLE
Use PDF template when generating results

### DIFF
--- a/assessform.html
+++ b/assessform.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Golf Club Cybersecurity & IT Initial Assessment - Pearl Solutions Group</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf-lib/1.17.1/pdf-lib.min.js"></script>
     <style>
         * {
             margin: 0;
@@ -987,178 +987,261 @@
             document.getElementById('results').scrollIntoView({ behavior: 'smooth' });
         }
 
-        function saveToPDF() {
-            const { jsPDF } = window.jspdf;
-            const pdf = new jsPDF();
-            const today = new Date().toLocaleDateString();
+        async function saveToPDF() {
+            try {
+                const participant = {
+                    firstName: document.getElementById('firstName').value.trim(),
+                    lastName: document.getElementById('lastName').value.trim(),
+                    email: document.getElementById('email').value.trim(),
+                    clubName: document.getElementById('clubname').value.trim()
+                };
 
-            // ---------- COVER PAGE ----------
-            let y = 20;
+                const questions = [
+                    'Do you process credit cards anywhere in your club (pro shop, restaurant, beverage carts, etc.)?',
+                    'Are you PCI DSS compliant across all payment locations?',
+                    'Are your data backups tested monthly, encrypted, and stored both onsite and offsite with at least one air-gapped copy?',
+                    'Do you have a tested plan for getting back online quickly if ransomware locks all your systems?',
+                    'Is your network properly segmented with firewalls separating member systems, staff systems, and guest WiFi?',
+                    'Are all your servers, workstations, and network equipment under warranty with a documented hardware refresh cycle?',
+                    'Is access removed immediately when employees leave?',
+                    'Do you audit user access quarterly and remove unnecessary permissions?',
+                    'Do you have documented policies for member data collection, storage, and privacy rights?',
+                    'Do you have 24/7 security monitoring with immediate threat response?',
+                    'Do all staff receive annual cybersecurity training with simulated phishing tests?',
+                    'Do you have redundant internet connections that automatically switch during outages?',
+                    'Do you have a disaster response team with clear roles and communication protocols?'
+                ];
 
-            // Title
-            pdf.setFontSize(18);
-            pdf.text('Golf Club Cybersecurity Initial Assessment Results', 105, y, { align: 'center' });
+                const answers = [];
+                let yesCount = 0;
+                let noCount = 0;
+                let unsureCount = 0;
+                let naCount = 0;
 
-            y += 10;
-            pdf.setFontSize(12);
-            pdf.text("Pearl Solutions Group - Your Club's Digital Caddie", 105, y, { align: 'center' });
-
-            y += 10;
-            pdf.text(`Assessment Date: ${today}`, 105, y, { align: 'center' });
-
-            // Client Info
-            y += 20;
-            pdf.setFontSize(12);
-            pdf.text(`Prepared For: ${formData.firstName} ${formData.lastName}`, 20, y);
-
-            y += 7;
-            pdf.text(`Email: ${formData.email}`, 20, y);
-
-            // Risk Level
-            const riskLevel = document.getElementById('riskLevel').textContent;
-            y += 20;
-            pdf.setFontSize(16);
-            pdf.text(`Risk Level: ${riskLevel}`, 20, y);
-
-            // Collect answers
-            let yesCount = 0, noCount = 0, unsureCount = 0, naCount = 0;
-            let answers = [];
-
-            const questions = [
-                'Do you process credit cards anywhere in your club (pro shop, restaurant, beverage carts, etc.)?',
-                'Are you PCI DSS compliant across all payment locations?',
-                'Are your data backups tested monthly, encrypted, and stored both onsite and offsite with at least one air-gapped copy?',
-                'Do you have a tested plan for getting back online quickly if ransomware locks all your systems?',
-                'Is your network properly segmented with firewalls separating member systems, staff systems, and guest WiFi?',
-                'Are all your servers, workstations, and network equipment under warranty with a documented hardware refresh cycle?',
-                'Is access removed immediately when employees leave?',
-                'Do you audit user access quarterly and remove unnecessary permissions?',
-                'Do you have documented policies for member data collection, storage, and privacy rights?',
-                'Do you have 24/7 security monitoring with immediate threat response?',
-                'Do all staff receive annual cybersecurity training with simulated phishing tests?',
-                'Do you have redundant internet connections that automatically switch during outages?',
-                'Do you have a disaster response team with clear roles and communication protocols?'
-            ];
-
-            for (let i = 1; i <= 13; i++) {
-                const selected = document.querySelector(`input[name="q${i}"]:checked`);
-                if (selected) {
-                    answers.push(selected.value);
-                    if (selected.value === 'yes') yesCount++;
-                    else if (selected.value === 'no') noCount++;
-                    else if (selected.value === 'unsure') unsureCount++;
-                    else if (selected.value === 'na') naCount++;
-                } else {
-                    answers.push('Not Answered');
-                }
-            }
-
-            // Summary
-            y += 20;
-            pdf.setFontSize(14);
-            pdf.text('Initial Assessment Summary:', 20, y);
-
-            y += 10;
-            pdf.setFontSize(12);
-            pdf.text(`Yes Answers: ${yesCount}/13`, 30, y);
-
-            y += 7;
-            pdf.text(`No Answers: ${noCount}/13`, 30, y);
-
-            y += 7;
-            pdf.text(`Unsure Answers: ${unsureCount}/13`, 30, y);
-
-            y += 7;
-            pdf.text(`Not Applicable: ${naCount}/13`, 30, y);
-
-            // ---------- QUESTIONS & ANSWERS ----------
-            pdf.addPage();
-            pdf.setFontSize(16);
-            pdf.text('Assessment Questions & Responses', 105, 20, { align: 'center' });
-
-            y = 35;
-            pdf.setFontSize(10);
-
-            questions.forEach((question, index) => {
-                if (y > 270) {
-                    pdf.addPage();
-                    y = 20;
+                for (let i = 1; i <= questions.length; i++) {
+                    const selected = document.querySelector(`input[name="q${i}"]:checked`);
+                    if (selected) {
+                        answers.push(selected.value);
+                        if (selected.value === 'yes') yesCount++;
+                        else if (selected.value === 'no') noCount++;
+                        else if (selected.value === 'unsure') unsureCount++;
+                        else if (selected.value === 'na') naCount++;
+                    } else {
+                        answers.push('Not Answered');
+                    }
                 }
 
-                // Question
-                const questionLines = pdf.splitTextToSize(`${index + 1}. ${question}`, 170);
-                questionLines.forEach(line => {
-                    pdf.text(line, 20, y);
-                    y += 5;
+                const riskLevelText = document.getElementById('riskLevel').innerText;
+                const riskClass = document.getElementById('riskLevel').className.replace('risk-level', '').trim();
+                const detailsText = document.getElementById('riskDetails').innerText;
+                const recsText = document.getElementById('recommendations').innerText;
+                const today = new Date().toLocaleDateString();
+
+                const { PDFDocument, rgb, StandardFonts } = PDFLib;
+
+                const templateResponse = await fetch('Golf Assessment Results Background .pdf');
+                if (!templateResponse.ok) {
+                    throw new Error('Unable to load template PDF');
+                }
+                const templateBytes = await templateResponse.arrayBuffer();
+
+                const pdfDoc = await PDFDocument.load(templateBytes);
+                const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+                const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+
+                const pages = pdfDoc.getPages();
+                let currentPage = pages[0];
+                const pageWidth = currentPage.getWidth();
+                const pageHeight = currentPage.getHeight();
+                const topMarginFirstPage = 140;
+                const topMargin = 70;
+                const bottomMargin = 50;
+                const contentWidth = pageWidth - 120;
+
+                let yOffset = topMarginFirstPage;
+
+                const riskColors = {
+                    'risk-low': rgb(0, 128 / 255, 0),
+                    'risk-medium': rgb(204 / 255, 140 / 255, 0),
+                    'risk-high': rgb(204 / 255, 51 / 255, 51 / 255),
+                    'risk-critical': rgb(153 / 255, 0, 0)
+                };
+
+                const answerColors = {
+                    yes: rgb(0, 128 / 255, 0),
+                    no: rgb(1, 0, 0),
+                    unsure: rgb(128 / 255, 128 / 255, 128 / 255),
+                    na: rgb(23 / 255, 162 / 255, 184 / 255)
+                };
+
+                const ensureSpace = (lineHeight = 18) => {
+                    if (yOffset + lineHeight > pageHeight - bottomMargin) {
+                        currentPage = pdfDoc.addPage([pageWidth, pageHeight]);
+                        yOffset = topMargin;
+                    }
+                };
+
+                const drawLine = ({ text, x = 60, font = regularFont, size = 12, color = rgb(0, 0, 0), lineHeight = 18 }) => {
+                    ensureSpace(lineHeight);
+                    currentPage.drawText(text, {
+                        x,
+                        y: pageHeight - yOffset,
+                        size,
+                        font,
+                        color
+                    });
+                    yOffset += lineHeight;
+                };
+
+                const drawCentered = ({ text, font = boldFont, size = 16, color = rgb(0, 0, 0), lineHeight = 24 }) => {
+                    ensureSpace(lineHeight);
+                    const textWidth = font.widthOfTextAtSize(text, size);
+                    const x = (pageWidth - textWidth) / 2;
+                    currentPage.drawText(text, {
+                        x,
+                        y: pageHeight - yOffset,
+                        size,
+                        font,
+                        color
+                    });
+                    yOffset += lineHeight;
+                };
+
+                const wrapText = (text, maxWidth, font, size) => {
+                    const words = text.split(/\s+/);
+                    const lines = [];
+                    let currentLine = '';
+
+                    words.forEach(word => {
+                        const testLine = currentLine ? `${currentLine} ${word}` : word;
+                        const width = font.widthOfTextAtSize(testLine, size);
+                        if (width <= maxWidth) {
+                            currentLine = testLine;
+                        } else {
+                            if (currentLine) {
+                                lines.push(currentLine);
+                            }
+                            currentLine = word;
+                        }
+                    });
+
+                    if (currentLine) {
+                        lines.push(currentLine);
+                    }
+
+                    return lines;
+                };
+
+                const drawParagraph = (text, { x = 60, font = regularFont, size = 12, lineHeight = 18, color = rgb(0, 0, 0), maxWidth = contentWidth } = {}) => {
+                    const paragraphs = text
+                        .split(/\r?\n/)
+                        .map(line => line.trim())
+                        .filter(line => line.length > 0);
+
+                    paragraphs.forEach((paragraph, index) => {
+                        const lines = wrapText(paragraph, maxWidth, font, size);
+                        lines.forEach(line => {
+                            drawLine({ text: line, x, font, size, color, lineHeight });
+                        });
+                        if (index < paragraphs.length - 1) {
+                            yOffset += lineHeight;
+                        }
+                    });
+                };
+
+                drawCentered({ text: 'Golf Club Cybersecurity Initial Assessment Results', size: 18 });
+                drawCentered({ text: "Pearl Solutions Group - Your Club's Digital Caddie", font: regularFont, size: 12, lineHeight: 18 });
+                drawCentered({ text: `Assessment Date: ${today}`, font: regularFont, size: 12, lineHeight: 18 });
+
+                yOffset += 10;
+                drawLine({ text: `Prepared For: ${participant.firstName} ${participant.lastName}` });
+                drawLine({ text: `Email: ${participant.email}` });
+                drawLine({ text: `Club / Organization: ${participant.clubName}` });
+
+                yOffset += 10;
+                drawLine({
+                    text: `Risk Level: ${riskLevelText}`,
+                    font: boldFont,
+                    size: 16,
+                    color: riskColors[riskClass] || rgb(0, 0, 0),
+                    lineHeight: 24
                 });
 
-                // Answer with color coding
-                const answer = answers[index];
-                if (answer === 'yes') {
-                    pdf.setTextColor(0, 128, 0); // Green
-                } else if (answer === 'no') {
-                    pdf.setTextColor(255, 0, 0); // Red
-                } else if (answer === 'na') {
-                    pdf.setTextColor(23, 162, 184); // Teal
-                } else {
-                    pdf.setTextColor(128, 128, 128); // Gray
-                }
+                yOffset += 10;
+                drawLine({ text: 'Initial Assessment Summary:', font: boldFont, size: 14, lineHeight: 22 });
+                drawLine({ text: `Yes Answers: ${yesCount}/${questions.length}`, x: 80 });
+                drawLine({ text: `No Answers: ${noCount}/${questions.length}`, x: 80 });
+                drawLine({ text: `Unsure Answers: ${unsureCount}/${questions.length}`, x: 80 });
+                drawLine({ text: `Not Applicable: ${naCount}/${questions.length}`, x: 80 });
 
-                pdf.text(`Answer: ${answer.toUpperCase()}`, 30, y);
-                pdf.setTextColor(0, 0, 0); // Reset to black
-                y += 10;
-            });
+                currentPage = pdfDoc.addPage([pageWidth, pageHeight]);
+                yOffset = topMargin;
 
-            // ---------- RISK ASSESSMENT ----------
-            pdf.addPage();
-            pdf.setFontSize(14);
-            pdf.text('Risk Analysis & Recommendations:', 20, 20);
+                drawCentered({ text: 'Assessment Questions & Responses', size: 16 });
+                yOffset += 10;
 
-            const riskText = document.getElementById('riskLevel').innerText;
-            const detailsText = document.getElementById('riskDetails').innerText;
-            const recsText = document.getElementById('recommendations').innerText;
+                questions.forEach((question, index) => {
+                    const questionLines = wrapText(`${index + 1}. ${question}`, contentWidth, regularFont, 11);
+                    questionLines.forEach(line => {
+                        drawLine({ text: line, x: 60, font: regularFont, size: 11, lineHeight: 16 });
+                    });
 
-            pdf.setFontSize(12);
-            const riskLines = pdf.splitTextToSize(`Risk Level: ${riskText}`, 170);
-            y = 35;
-            riskLines.forEach(line => {
-                pdf.text(line, 20, y);
-                y += 7;
-            });
+                    const answer = answers[index];
+                    const color = answerColors[answer] || rgb(128 / 255, 128 / 255, 128 / 255);
+                    drawLine({
+                        text: `Answer: ${answer.toUpperCase()}`,
+                        x: 80,
+                        font: boldFont,
+                        size: 11,
+                        color,
+                        lineHeight: 16
+                    });
 
-            y += 5;
-            const detailLines = pdf.splitTextToSize(detailsText, 170);
-            detailLines.forEach(line => {
-                if (y > 280) {
-                    pdf.addPage();
-                    y = 20;
-                }
-                pdf.text(line, 20, y);
-                y += 7;
-            });
+                    yOffset += 6;
+                });
 
-            y += 10;
-            pdf.text('Recommended Next Steps:', 20, y);
-            y += 10;
-            const recLines = pdf.splitTextToSize(recsText, 170);
-            recLines.forEach(line => {
-                if (y > 280) {
-                    pdf.addPage();
-                    y = 20;
-                }
-                pdf.text(line, 20, y);
-                y += 7;
-            });
+                currentPage = pdfDoc.addPage([pageWidth, pageHeight]);
+                yOffset = topMargin;
 
-            // ---------- FOOTER ----------
-            const totalPages = pdf.internal.getNumberOfPages();
-            for (let i = 1; i <= totalPages; i++) {
-                pdf.setPage(i);
-                pdf.setFontSize(8);
-                pdf.text("Pearl Solutions Group | (636) 949-8850 | Your Club's Digital Caddie", 105, 290, { align: 'center' });
+                drawLine({ text: 'Risk Analysis & Recommendations:', font: boldFont, size: 14, lineHeight: 24 });
+                drawParagraph(`Risk Level: ${riskLevelText}`, { font: regularFont, size: 12 });
+
+                yOffset += 10;
+                drawParagraph(detailsText, { font: regularFont, size: 12 });
+
+                yOffset += 10;
+                drawLine({ text: 'Recommended Next Steps:', font: boldFont, size: 12, lineHeight: 22 });
+                drawParagraph(recsText, { font: regularFont, size: 12 });
+
+                const footerText = "Pearl Solutions Group | (636) 949-8850 | Your Club's Digital Caddie";
+                const allPages = pdfDoc.getPages();
+                allPages.forEach(page => {
+                    const textWidth = regularFont.widthOfTextAtSize(footerText, 8);
+                    page.drawText(footerText, {
+                        x: (page.getWidth() - textWidth) / 2,
+                        y: 30,
+                        size: 8,
+                        font: regularFont,
+                        color: rgb(0, 0, 0)
+                    });
+                });
+
+                const pdfBytes = await pdfDoc.save();
+                const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+                const url = URL.createObjectURL(blob);
+
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = 'Golf-Club-Security-Assessment-Results.pdf';
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+
+                setTimeout(() => URL.revokeObjectURL(url), 1000);
+            } catch (error) {
+                console.error('Error generating PDF', error);
+                alert('There was a problem generating the PDF. Please try again.');
             }
-
-            pdf.save('Golf-Club-Security-Assessment-Results.pdf');
         }
 
     </script>


### PR DESCRIPTION
## Summary
- replace the jsPDF implementation with pdf-lib so the generated report is drawn directly on top of the provided background template
- lay out participant details, assessment summaries, and answers on the template and continue subsequent pages with wrapped content
- add error handling around template loading and PDF creation

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d45d1b75e88324830066b356545b6a