### PR TITLE
Prevent duplicate button handlers when inline callbacks exist

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -491,15 +491,26 @@
       }
     };
 
+    const hasCalcBtnInlineHandler = Boolean(
+      calcBtn && (calcBtn.hasAttribute('onclick') || typeof calcBtn.onclick === 'function')
+    );
+
+    const hasSaveBtnInlineHandler = Boolean(
+      savePdfBtn && (savePdfBtn.hasAttribute('onclick') || typeof savePdfBtn.onclick === 'function')
+    );
+
     if (calcBtn) {
       calcBtn.disabled = true;
-      calcBtn.addEventListener('click', event => {
-        event.preventDefault();
-        calculateScore();
-      });
+
+      if (!hasCalcBtnInlineHandler) {
+        calcBtn.addEventListener('click', event => {
+          event.preventDefault();
+          calculateScore();
+        });
+      }
     }
 
-    if (savePdfBtn) {
+    if (savePdfBtn && !hasSaveBtnInlineHandler) {
       savePdfBtn.addEventListener('click', event => {
         event.preventDefault();
         saveToPDF();


### PR DESCRIPTION
## Summary
- detect existing inline handlers on the calculator and PDF buttons
- only add module event listeners when no inline handlers exist to avoid duplicate submissions

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6f0140d748324a05ddb256ee20a2c