### PR TITLE
Handle empty HubSpot responses gracefully

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -53,10 +53,27 @@
           body: JSON.stringify(payload)
         });
 
+        const status = response.status;
+        const contentLengthHeader = response.headers.get('Content-Length');
+        const hasBody = status !== 204 && contentLengthHeader !== '0';
+
         if (!response.ok) {
-          console.error('HubSpot submission failed', await response.text());
-        } else {
+          const rawText = hasBody ? await response.text() : '';
+          console.error('HubSpot submission failed', rawText || `Status ${status}`);
+          return;
+        }
+
+        if (!hasBody) {
+          console.log('HubSpot submission success: No content returned.');
+          return;
+        }
+
+        const contentType = response.headers.get('Content-Type') || '';
+
+        if (contentType.includes('application/json')) {
           console.log('HubSpot submission success:', await response.json());
+        } else {
+          console.log('HubSpot submission success (non-JSON response):', await response.text());
         }
       } catch (err) {
         console.error('Error sending to HubSpot', err);


### PR DESCRIPTION
## Summary
- check HubSpot submission responses for status codes and content length before parsing
- skip JSON parsing for empty or 204 responses while logging a clear success message
- capture raw response text for failed submissions to aid troubleshooting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6f015bf1083248e68eabce075054a