### PR TITLE
Submit HubSpot form when risk assessment is calculated

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -80,7 +80,7 @@
       }
     };
 
-    const calculateScore = () => {
+    const calculateScore = async () => {
       const assessmentForm = document.getElementById('assessmentForm');
       if (!assessmentForm) {
         return;
@@ -243,6 +243,10 @@
       if (resultsContainer) {
         resultsContainer.scrollIntoView({ behavior: 'smooth' });
       }
+
+      const participant = captureParticipant();
+      const riskLevelText = riskLevel;
+      await sendToHubSpot(participant, riskLevelText);
     };
 
     const saveToPDF = async () => {
@@ -255,8 +259,6 @@
         }
 
         const riskLevelText = riskLevelEl.innerText.trim();
-
-        await sendToHubSpot(participant, riskLevelText);
 
         const questions = [
           'Do you process credit cards anywhere in your club (pro shop, restaurant, beverage carts, etc.)?',
@@ -520,9 +522,9 @@
       calcBtn.disabled = true;
 
       if (!hasCalcBtnInlineHandler) {
-        calcBtn.addEventListener('click', event => {
+        calcBtn.addEventListener('click', async event => {
           event.preventDefault();
-          calculateScore();
+          await calculateScore();
         });
       }
     }


### PR DESCRIPTION
## Summary
- trigger HubSpot form submission immediately after a successful risk assessment calculation
- remove the HubSpot submission dependency from the PDF download workflow
- update the calculate button listener to await the async scoring routine

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daea7e0cac83248598244b83f35d15