### PR TITLE
Remove PDF template fetch to prevent 404 errors

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -334,22 +334,9 @@
 
         const pdfDoc = await PDFDocument.create();
 
-        let templateBackground;
-        let pageWidth = 612;
-        let pageHeight = 792;
-
-        try {
-          const templateResponse = await fetch('golf-assessment-results-background.pdf');
-          if (!templateResponse.ok) {
-            throw new Error(`Template fetch failed with status ${templateResponse.status}`);
-          }
-          const templateBytes = await templateResponse.arrayBuffer();
-          [templateBackground] = await pdfDoc.embedPdf(templateBytes);
-          pageWidth = templateBackground.width;
-          pageHeight = templateBackground.height;
-        } catch (templateError) {
-          console.warn('Unable to load template PDF. Falling back to a simplified layout.', templateError);
-        }
+        const templateBackground = null;
+        const pageWidth = 612;
+        const pageHeight = 792;
 
         const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
         const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);


### PR DESCRIPTION
## Summary
- stop requesting the background PDF when generating the assessment report to avoid 404 console errors
- rely on the existing simplified PDF layout so report generation continues to work without the missing asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbed4d20c88324b3834821a8ed8842