### PR TITLE
Attach generated assessment PDF to HubSpot submissions

### DIFF
--- a/wordpress.html
+++ b/wordpress.html
@@ -815,6 +815,31 @@
       document.getElementById('clubname')
     ];
 
+    const ASSESSMENT_QUESTIONS = [
+      'Do you process credit cards anywhere in your club (pro shop, restaurant, beverage carts, etc.)?',
+      'Are you PCI DSS compliant across all payment locations?',
+      'Are your data backups tested monthly, encrypted, and stored both onsite and offsite with at least one air-gapped copy?',
+      'Do you have a tested plan for getting back online quickly if ransomware locks all your systems?',
+      'Is your network properly segmented with firewalls separating member systems, staff systems, and guest WiFi?',
+      'Are all your servers, workstations, and network equipment under warranty with a documented hardware refresh cycle?',
+      'Is access removed immediately when employees leave?',
+      'Do you audit user access quarterly and remove unnecessary permissions?',
+      'Do you have documented policies for member data collection, storage, and privacy rights?',
+      'Do you have 24/7 security monitoring with immediate threat response?',
+      'Do all staff receive annual cybersecurity training with simulated phishing tests?',
+      'Do you have redundant internet connections that automatically switch during outages?',
+      'Do you have a disaster response team with clear roles and communication protocols?'
+    ];
+
+    const HUBSPOT_RESULTS_PDF_FIELD = 'results_pdf';
+    const PDF_TEMPLATE_URL = 'https://pearlsolves.com/wp-content/uploads/2025/09/Golf-Assessment-Results-Background-.pdf';
+    const RESULTS_PDF_FILE_NAME = 'Golf-Club-Security-Assessment-Results.pdf';
+
+    let templatePdfBytesCache = null;
+    let latestPdfBytesCache = null;
+    let latestPdfSignature = '';
+    let latestPdfBase64Cache = '';
+
     const captureParticipant = () => ({
       firstName: document.getElementById('firstName').value.trim(),
       lastName: document.getElementById('lastName').value.trim(),
@@ -835,8 +860,295 @@
       }
     });
 
+    const arrayBufferToBase64 = bytes => {
+      if (!bytes || !bytes.length) {
+        return '';
+      }
+
+      const chunkSize = 0x8000;
+      let binary = '';
+
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        const chunk = bytes.subarray(i, i + chunkSize);
+        binary += String.fromCharCode.apply(null, chunk);
+      }
+
+      return window.btoa(binary);
+    };
+
+    const getAssessmentSnapshot = (participantOverride, riskLevelOverride) => {
+      const participant = participantOverride || captureParticipant();
+      const riskLevelEl = document.getElementById('riskLevel');
+      const riskLevelText = riskLevelOverride || (riskLevelEl ? riskLevelEl.innerText.trim() : '');
+
+      if (!riskLevelText) {
+        throw new Error('Risk level not yet calculated.');
+      }
+
+      const riskClass = riskLevelEl ? riskLevelEl.className.replace('risk-level', '').trim() : '';
+
+      const answers = [];
+      let yesCount = 0;
+      let noCount = 0;
+      let unsureCount = 0;
+      let naCount = 0;
+
+      ASSESSMENT_QUESTIONS.forEach((question, index) => {
+        const selected = document.querySelector(`input[name="q${index + 1}"]:checked`);
+        if (selected) {
+          answers.push(selected.value);
+          if (selected.value === 'yes') {
+            yesCount += 1;
+          } else if (selected.value === 'no') {
+            noCount += 1;
+          } else if (selected.value === 'unsure') {
+            unsureCount += 1;
+          } else if (selected.value === 'na') {
+            naCount += 1;
+          }
+        } else {
+          answers.push('Not Answered');
+        }
+      });
+
+      const detailsElement = document.getElementById('riskDetails');
+      const recommendationsElement = document.getElementById('recommendations');
+
+      return {
+        participant,
+        riskLevelText,
+        riskClass,
+        answers,
+        yesCount,
+        noCount,
+        unsureCount,
+        naCount,
+        detailsText: detailsElement ? detailsElement.innerText : '',
+        recsText: recommendationsElement ? recommendationsElement.innerText : '',
+        today: new Date().toLocaleDateString()
+      };
+    };
+
+    const createSnapshotSignature = snapshot => JSON.stringify({
+      participant: snapshot.participant,
+      riskLevelText: snapshot.riskLevelText,
+      riskClass: snapshot.riskClass,
+      answers: snapshot.answers,
+      counts: [snapshot.yesCount, snapshot.noCount, snapshot.unsureCount, snapshot.naCount],
+      details: snapshot.detailsText,
+      recs: snapshot.recsText,
+      today: snapshot.today
+    });
+
+    const generateAssessmentPdfBytes = async snapshot => {
+      const signature = createSnapshotSignature(snapshot);
+      if (latestPdfBytesCache && signature === latestPdfSignature) {
+        return { pdfBytes: latestPdfBytesCache, signature };
+      }
+
+      const { PDFDocument, rgb, StandardFonts } = window.PDFLib || {};
+      if (!PDFDocument || !rgb || !StandardFonts) {
+        throw new Error('PDFLib failed to load.');
+      }
+
+      if (!templatePdfBytesCache) {
+        const templateResponse = await fetch(PDF_TEMPLATE_URL);
+        if (!templateResponse.ok) {
+          throw new Error('Unable to load template PDF');
+        }
+        templatePdfBytesCache = new Uint8Array(await templateResponse.arrayBuffer());
+      }
+
+      const pdfDoc = await PDFDocument.create();
+      const [templateBackground] = await pdfDoc.embedPdf(templatePdfBytesCache);
+      const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+      const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+
+      const pageWidth = templateBackground.width;
+      const pageHeight = templateBackground.height;
+      const topMarginFirstPage = 140;
+      const topMargin = 70;
+      const bottomMargin = 50;
+      const contentWidth = pageWidth - 120;
+
+      const addPageWithTemplate = () => {
+        const page = pdfDoc.addPage([pageWidth, pageHeight]);
+        page.drawPage(templateBackground, {
+          x: 0,
+          y: 0,
+          width: pageWidth,
+          height: pageHeight
+        });
+        return page;
+      };
+
+      let currentPage = addPageWithTemplate();
+      let yOffset = topMarginFirstPage;
+
+      const riskColors = {
+        'risk-low': rgb(0, 128 / 255, 0),
+        'risk-medium': rgb(204 / 255, 140 / 255, 0),
+        'risk-high': rgb(204 / 255, 51 / 255, 51 / 255),
+        'risk-critical': rgb(153 / 255, 0, 0)
+      };
+
+      const answerColors = {
+        yes: rgb(0, 128 / 255, 0),
+        no: rgb(1, 0, 0),
+        unsure: rgb(128 / 255, 128 / 255, 128 / 255),
+        na: rgb(23 / 255, 162 / 255, 184 / 255)
+      };
+
+      const ensureSpace = (lineHeight = 18) => {
+        if (yOffset + lineHeight > pageHeight - bottomMargin) {
+          currentPage = addPageWithTemplate();
+          yOffset = topMargin;
+        }
+      };
+
+      const drawLine = ({ text, x = 60, font = regularFont, size = 12, color = rgb(0, 0, 0), lineHeight = 18 }) => {
+        ensureSpace(lineHeight);
+        currentPage.drawText(text, {
+          x,
+          y: pageHeight - yOffset,
+          size,
+          font,
+          color
+        });
+        yOffset += lineHeight;
+      };
+
+      const drawCentered = ({ text, font = boldFont, size = 16, color = rgb(0, 0, 0), lineHeight = 24 }) => {
+        ensureSpace(lineHeight);
+        const textWidth = font.widthOfTextAtSize(text, size);
+        const x = (pageWidth - textWidth) / 2;
+        currentPage.drawText(text, {
+          x,
+          y: pageHeight - yOffset,
+          size,
+          font,
+          color
+        });
+        yOffset += lineHeight;
+      };
+
+      const wrapText = (text, maxWidth, font, size) => {
+        const words = text.split(/\s+/);
+        const lines = [];
+        let currentLine = '';
+
+        words.forEach(word => {
+          const testLine = currentLine ? `${currentLine} ${word}` : word;
+          const width = font.widthOfTextAtSize(testLine, size);
+          if (width <= maxWidth) {
+            currentLine = testLine;
+          } else {
+            if (currentLine) {
+              lines.push(currentLine);
+            }
+            currentLine = word;
+          }
+        });
+
+        if (currentLine) {
+          lines.push(currentLine);
+        }
+
+        return lines;
+      };
+
+      const drawParagraph = (text, { x = 60, font = regularFont, size = 12, lineHeight = 18, color = rgb(0, 0, 0), maxWidth = contentWidth } = {}) => {
+        const paragraphs = text
+          .split(/\r?\n/)
+          .map(line => line.trim())
+          .filter(line => line.length > 0);
+
+        paragraphs.forEach((paragraph, index) => {
+          const lines = wrapText(paragraph, maxWidth, font, size);
+          lines.forEach(line => {
+            drawLine({ text: line, x, font, size, color, lineHeight });
+          });
+          if (index < paragraphs.length - 1) {
+            yOffset += lineHeight;
+          }
+        });
+      };
+
+      drawCentered({ text: 'Golf Club Cybersecurity Initial Assessment Results', size: 18 });
+      drawCentered({ text: "Pearl Solutions Group - Your Club's Digital Caddie", font: regularFont, size: 12, lineHeight: 18 });
+      drawCentered({ text: `Assessment Date: ${snapshot.today}`, font: regularFont, size: 12, lineHeight: 18 });
+
+      yOffset += 10;
+      drawLine({ text: `Prepared For: ${snapshot.participant.firstName} ${snapshot.participant.lastName}` });
+      drawLine({ text: `Email: ${snapshot.participant.email}` });
+      drawLine({ text: `Club / Organization: ${snapshot.participant.clubName}` });
+
+      yOffset += 10;
+      drawLine({
+        text: `Risk Level: ${snapshot.riskLevelText}`,
+        font: boldFont,
+        size: 16,
+        color: riskColors[snapshot.riskClass] || rgb(0, 0, 0),
+        lineHeight: 24
+      });
+
+      yOffset += 10;
+      drawLine({ text: 'Initial Assessment Summary:', font: boldFont, size: 14, lineHeight: 22 });
+      drawLine({ text: `Yes Answers: ${snapshot.yesCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
+      drawLine({ text: `No Answers: ${snapshot.noCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
+      drawLine({ text: `Unsure Answers: ${snapshot.unsureCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
+      drawLine({ text: `Not Applicable: ${snapshot.naCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
+
+      currentPage = addPageWithTemplate();
+      yOffset = topMargin;
+
+      drawCentered({ text: 'Assessment Questions & Responses', size: 16 });
+      yOffset += 10;
+
+      ASSESSMENT_QUESTIONS.forEach((question, index) => {
+        const questionLines = wrapText(`${index + 1}. ${question}`, contentWidth, regularFont, 11);
+        questionLines.forEach(line => {
+          drawLine({ text: line, x: 60, font: regularFont, size: 11, lineHeight: 16 });
+        });
+
+        const answer = snapshot.answers[index];
+        const color = answerColors[answer] || rgb(128 / 255, 128 / 255, 128 / 255);
+        drawLine({
+          text: `Answer: ${answer.toUpperCase()}`,
+          x: 80,
+          font: boldFont,
+          size: 11,
+          color,
+          lineHeight: 16
+        });
+
+        yOffset += 6;
+      });
+
+      currentPage = addPageWithTemplate();
+      yOffset = topMargin;
+
+      drawLine({ text: 'Risk Analysis & Recommendations:', font: boldFont, size: 14, lineHeight: 24 });
+      drawParagraph(`Risk Level: ${snapshot.riskLevelText}`, { font: regularFont, size: 12 });
+
+      yOffset += 10;
+      drawParagraph(snapshot.detailsText, { font: regularFont, size: 12 });
+
+      yOffset += 10;
+      drawLine({ text: 'Recommended Next Steps:', font: boldFont, size: 12, lineHeight: 22 });
+      drawParagraph(snapshot.recsText, { font: regularFont, size: 12 });
+
+      const pdfBytes = await pdfDoc.save();
+
+      latestPdfBytesCache = pdfBytes;
+      latestPdfSignature = signature;
+      latestPdfBase64Cache = '';
+
+      return { pdfBytes, signature };
+    };
+
     checkFormCompletion();
-    const sendToHubSpot = async (participant, riskLevelText) => {
+    const sendToHubSpot = async (participant, riskLevelText, pdfAttachment) => {
       const url = 'https://api.hsforms.com/submissions/v3/integration/submit/1959814/4861c8c2-4019-4bd8-9a4c-b1218c87d392';
 
       const payload = {
@@ -852,6 +1164,17 @@
           pageName: document.title
         }
       };
+
+      if (pdfAttachment && pdfAttachment.base64) {
+        payload.files = [
+          {
+            name: HUBSPOT_RESULTS_PDF_FIELD,
+            fileName: pdfAttachment.fileName || RESULTS_PDF_FILE_NAME,
+            content: pdfAttachment.base64,
+            mimeType: 'application/pdf'
+          }
+        ];
+      }
 
       try {
         const response = await fetch(url, {
@@ -899,7 +1222,7 @@
       let noCount = 0;
       let unsureCount = 0;
       let naCount = 0;
-      const totalQuestions = 13;
+      const totalQuestions = ASSESSMENT_QUESTIONS.length;
       let answeredQuestions = 0;
       let applicableQuestions = 0;
 
@@ -1055,7 +1378,30 @@
         const participant = captureParticipant();
         if (participant.firstName && participant.lastName && participant.email && participant.clubName) {
           const riskLevelText = riskLevelEl ? riskLevelEl.innerText.trim() : riskLevel;
-          await sendToHubSpot(participant, riskLevelText);
+
+          let pdfAttachment = null;
+          try {
+            const snapshot = getAssessmentSnapshot(participant, riskLevelText);
+            const { pdfBytes, signature } = await generateAssessmentPdfBytes(snapshot);
+
+            let pdfBase64 = latestPdfBase64Cache;
+            if (!pdfBase64 || signature !== latestPdfSignature) {
+              pdfBase64 = arrayBufferToBase64(pdfBytes);
+              latestPdfBase64Cache = pdfBase64;
+              latestPdfSignature = signature;
+            }
+
+            if (pdfBase64) {
+              pdfAttachment = {
+                base64: pdfBase64,
+                fileName: RESULTS_PDF_FILE_NAME
+              };
+            }
+          } catch (pdfError) {
+            console.error('Error preparing assessment PDF for HubSpot submission', pdfError);
+          }
+
+          await sendToHubSpot(participant, riskLevelText, pdfAttachment);
         } else {
           console.warn('Participant information incomplete; skipping HubSpot submission.');
         }
@@ -1066,254 +1412,28 @@
 
     const saveToPDF = async () => {
       try {
-        const participant = captureParticipant();
         const riskLevelEl = document.getElementById('riskLevel');
         if (!riskLevelEl || !riskLevelEl.innerText.trim()) {
           alert('Please calculate your risk assessment before downloading the PDF.');
           return;
         }
 
+        const participant = captureParticipant();
         const riskLevelText = riskLevelEl.innerText.trim();
+        const snapshot = getAssessmentSnapshot(participant, riskLevelText);
+        const { pdfBytes, signature } = await generateAssessmentPdfBytes(snapshot);
 
-        const questions = [
-          'Do you process credit cards anywhere in your club (pro shop, restaurant, beverage carts, etc.)?',
-          'Are you PCI DSS compliant across all payment locations?',
-          'Are your data backups tested monthly, encrypted, and stored both onsite and offsite with at least one air-gapped copy?',
-          'Do you have a tested plan for getting back online quickly if ransomware locks all your systems?',
-          'Is your network properly segmented with firewalls separating member systems, staff systems, and guest WiFi?',
-          'Are all your servers, workstations, and network equipment under warranty with a documented hardware refresh cycle?',
-          'Is access removed immediately when employees leave?',
-          'Do you audit user access quarterly and remove unnecessary permissions?',
-          'Do you have documented policies for member data collection, storage, and privacy rights?',
-          'Do you have 24/7 security monitoring with immediate threat response?',
-          'Do all staff receive annual cybersecurity training with simulated phishing tests?',
-          'Do you have redundant internet connections that automatically switch during outages?',
-          'Do you have a disaster response team with clear roles and communication protocols?'
-        ];
-
-        const answers = [];
-        let yesCount = 0;
-        let noCount = 0;
-        let unsureCount = 0;
-        let naCount = 0;
-
-        for (let i = 1; i <= questions.length; i += 1) {
-          const selected = document.querySelector(`input[name="q${i}"]:checked`);
-          if (selected) {
-            answers.push(selected.value);
-            if (selected.value === 'yes') yesCount += 1;
-            else if (selected.value === 'no') noCount += 1;
-            else if (selected.value === 'unsure') unsureCount += 1;
-            else if (selected.value === 'na') naCount += 1;
-          } else {
-            answers.push('Not Answered');
-          }
+        if (!latestPdfBase64Cache || signature !== latestPdfSignature) {
+          latestPdfBase64Cache = arrayBufferToBase64(pdfBytes);
+          latestPdfSignature = signature;
         }
 
-        const riskClass = riskLevelEl.className.replace('risk-level', '').trim();
-        const detailsElement = document.getElementById('riskDetails');
-        const recommendationsElement = document.getElementById('recommendations');
-        const detailsText = detailsElement ? detailsElement.innerText : '';
-        const recsText = recommendationsElement ? recommendationsElement.innerText : '';
-        const today = new Date().toLocaleDateString();
-
-        const { PDFDocument, rgb, StandardFonts } = window.PDFLib || {};
-        if (!PDFDocument || !rgb || !StandardFonts) {
-          throw new Error('PDFLib failed to load.');
-        }
-
-        const templateResponse = await fetch('https://pearlsolves.com/wp-content/uploads/2025/09/Golf-Assessment-Results-Background-.pdf');
-        if (!templateResponse.ok) {
-          throw new Error('Unable to load template PDF');
-        }
-        const templateBytes = await templateResponse.arrayBuffer();
-
-        const pdfDoc = await PDFDocument.create();
-        const [templateBackground] = await pdfDoc.embedPdf(templateBytes);
-        const regularFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
-        const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
-
-        const pageWidth = templateBackground.width;
-        const pageHeight = templateBackground.height;
-        const topMarginFirstPage = 140;
-        const topMargin = 70;
-        const bottomMargin = 50;
-        const contentWidth = pageWidth - 120;
-
-        const addPageWithTemplate = () => {
-          const page = pdfDoc.addPage([pageWidth, pageHeight]);
-          page.drawPage(templateBackground, {
-            x: 0,
-            y: 0,
-            width: pageWidth,
-            height: pageHeight
-          });
-          return page;
-        };
-
-        let currentPage = addPageWithTemplate();
-        let yOffset = topMarginFirstPage;
-
-        const riskColors = {
-          'risk-low': rgb(0, 128 / 255, 0),
-          'risk-medium': rgb(204 / 255, 140 / 255, 0),
-          'risk-high': rgb(204 / 255, 51 / 255, 51 / 255),
-          'risk-critical': rgb(153 / 255, 0, 0)
-        };
-
-        const answerColors = {
-          yes: rgb(0, 128 / 255, 0),
-          no: rgb(1, 0, 0),
-          unsure: rgb(128 / 255, 128 / 255, 128 / 255),
-          na: rgb(23 / 255, 162 / 255, 184 / 255)
-        };
-
-        const ensureSpace = (lineHeight = 18) => {
-          if (yOffset + lineHeight > pageHeight - bottomMargin) {
-            currentPage = addPageWithTemplate();
-            yOffset = topMargin;
-          }
-        };
-
-        const drawLine = ({ text, x = 60, font = regularFont, size = 12, color = rgb(0, 0, 0), lineHeight = 18 }) => {
-          ensureSpace(lineHeight);
-          currentPage.drawText(text, {
-            x,
-            y: pageHeight - yOffset,
-            size,
-            font,
-            color
-          });
-          yOffset += lineHeight;
-        };
-
-        const drawCentered = ({ text, font = boldFont, size = 16, color = rgb(0, 0, 0), lineHeight = 24 }) => {
-          ensureSpace(lineHeight);
-          const textWidth = font.widthOfTextAtSize(text, size);
-          const x = (pageWidth - textWidth) / 2;
-          currentPage.drawText(text, {
-            x,
-            y: pageHeight - yOffset,
-            size,
-            font,
-            color
-          });
-          yOffset += lineHeight;
-        };
-
-        const wrapText = (text, maxWidth, font, size) => {
-          const words = text.split(/\s+/);
-          const lines = [];
-          let currentLine = '';
-
-          words.forEach(word => {
-            const testLine = currentLine ? `${currentLine} ${word}` : word;
-            const width = font.widthOfTextAtSize(testLine, size);
-            if (width <= maxWidth) {
-              currentLine = testLine;
-            } else {
-              if (currentLine) {
-                lines.push(currentLine);
-              }
-              currentLine = word;
-            }
-          });
-
-          if (currentLine) {
-            lines.push(currentLine);
-          }
-
-          return lines;
-        };
-
-        const drawParagraph = (text, { x = 60, font = regularFont, size = 12, lineHeight = 18, color = rgb(0, 0, 0), maxWidth = contentWidth } = {}) => {
-          const paragraphs = text
-            .split(/\r?\n/)
-            .map(line => line.trim())
-            .filter(line => line.length > 0);
-
-          paragraphs.forEach((paragraph, index) => {
-            const lines = wrapText(paragraph, maxWidth, font, size);
-            lines.forEach(line => {
-              drawLine({ text: line, x, font, size, color, lineHeight });
-            });
-            if (index < paragraphs.length - 1) {
-              yOffset += lineHeight;
-            }
-          });
-        };
-
-        drawCentered({ text: 'Golf Club Cybersecurity Initial Assessment Results', size: 18 });
-        drawCentered({ text: "Pearl Solutions Group - Your Club's Digital Caddie", font: regularFont, size: 12, lineHeight: 18 });
-        drawCentered({ text: `Assessment Date: ${today}`, font: regularFont, size: 12, lineHeight: 18 });
-
-        yOffset += 10;
-        drawLine({ text: `Prepared For: ${participant.firstName} ${participant.lastName}` });
-        drawLine({ text: `Email: ${participant.email}` });
-        drawLine({ text: `Club / Organization: ${participant.clubName}` });
-
-        yOffset += 10;
-        drawLine({
-          text: `Risk Level: ${riskLevelText}`,
-          font: boldFont,
-          size: 16,
-          color: riskColors[riskClass] || rgb(0, 0, 0),
-          lineHeight: 24
-        });
-
-        yOffset += 10;
-        drawLine({ text: 'Initial Assessment Summary:', font: boldFont, size: 14, lineHeight: 22 });
-        drawLine({ text: `Yes Answers: ${yesCount}/${questions.length}`, x: 80 });
-        drawLine({ text: `No Answers: ${noCount}/${questions.length}`, x: 80 });
-        drawLine({ text: `Unsure Answers: ${unsureCount}/${questions.length}`, x: 80 });
-        drawLine({ text: `Not Applicable: ${naCount}/${questions.length}`, x: 80 });
-
-        currentPage = addPageWithTemplate();
-        yOffset = topMargin;
-
-        drawCentered({ text: 'Assessment Questions & Responses', size: 16 });
-        yOffset += 10;
-
-        questions.forEach((question, index) => {
-          const questionLines = wrapText(`${index + 1}. ${question}`, contentWidth, regularFont, 11);
-          questionLines.forEach(line => {
-            drawLine({ text: line, x: 60, font: regularFont, size: 11, lineHeight: 16 });
-          });
-
-          const answer = answers[index];
-          const color = answerColors[answer] || rgb(128 / 255, 128 / 255, 128 / 255);
-          drawLine({
-            text: `Answer: ${answer.toUpperCase()}`,
-            x: 80,
-            font: boldFont,
-            size: 11,
-            color,
-            lineHeight: 16
-          });
-
-          yOffset += 6;
-        });
-
-        currentPage = addPageWithTemplate();
-        yOffset = topMargin;
-
-        drawLine({ text: 'Risk Analysis & Recommendations:', font: boldFont, size: 14, lineHeight: 24 });
-        drawParagraph(`Risk Level: ${riskLevelText}`, { font: regularFont, size: 12 });
-
-        yOffset += 10;
-        drawParagraph(detailsText, { font: regularFont, size: 12 });
-
-        yOffset += 10;
-        drawLine({ text: 'Recommended Next Steps:', font: boldFont, size: 12, lineHeight: 22 });
-        drawParagraph(recsText, { font: regularFont, size: 12 });
-
-        const pdfBytes = await pdfDoc.save();
         const blob = new Blob([pdfBytes], { type: 'application/pdf' });
         const url = URL.createObjectURL(blob);
 
         const link = document.createElement('a');
         link.href = url;
-        link.download = 'Golf-Club-Security-Assessment-Results.pdf';
+        link.download = RESULTS_PDF_FILE_NAME;
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);


### PR DESCRIPTION
## Summary
- add shared helpers to generate assessment snapshots and PDFs from the existing questionnaire
- attach the generated PDF to HubSpot submissions through the new results_pdf field while caching the binary/base64 payload
- reuse the shared PDF generation for the download button to keep the output in sync with the HubSpot attachment

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc34ea5fe4832482e6567346b6879a