### PR TITLE
Include HubSpot hutk cookie in submissions

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -29,6 +29,22 @@
       }
     });
 
+    const getHubSpotUtk = () => {
+      const cookies = (document.cookie || '').split(';');
+      const entry = cookies.find(cookie => cookie.trim().startsWith('hubspotutk='));
+      if (!entry) {
+        return undefined;
+      }
+
+      const value = entry.trim().slice('hubspotutk='.length);
+      try {
+        return decodeURIComponent(value);
+      } catch (err) {
+        console.warn('Failed to decode hubspotutk cookie', err);
+        return undefined;
+      }
+    };
+
     const sendToHubSpot = async (participant, riskLevelText) => {
       const url = 'https://api.hsforms.com/submissions/v3/integration/submit/1959814/4861c8c2-4019-4bd8-9a4c-b1218c87d392';
 
@@ -45,6 +61,11 @@
           pageName: document.title
         }
       };
+
+      const hubSpotUtk = getHubSpotUtk();
+      if (hubSpotUtk) {
+        payload.context.hutk = hubSpotUtk;
+      }
 
       try {
         const response = await fetch(url, {

--- a/wordpress.html
+++ b/wordpress.html
@@ -1164,6 +1164,23 @@
     };
 
     checkFormCompletion();
+
+    const getHubSpotUtk = () => {
+      const cookies = (document.cookie || '').split(';');
+      const entry = cookies.find(cookie => cookie.trim().startsWith('hubspotutk='));
+      if (!entry) {
+        return undefined;
+      }
+
+      const value = entry.trim().slice('hubspotutk='.length);
+      try {
+        return decodeURIComponent(value);
+      } catch (err) {
+        console.warn('Failed to decode hubspotutk cookie', err);
+        return undefined;
+      }
+    };
+
     const sendToHubSpot = async (participant, riskLevelText, pdfAttachment) => {
       const url = 'https://api.hsforms.com/submissions/v3/integration/submit/1959814/4861c8c2-4019-4bd8-9a4c-b1218c87d392';
 
@@ -1180,6 +1197,11 @@
           pageName: document.title
         }
       };
+
+      const hubSpotUtk = getHubSpotUtk();
+      if (hubSpotUtk) {
+        payload.context.hutk = hubSpotUtk;
+      }
 
       if (pdfAttachment && pdfAttachment.base64) {
         payload.files = [

--- a/wpBackup.html
+++ b/wpBackup.html
@@ -836,6 +836,23 @@
     });
 
     checkFormCompletion();
+
+    const getHubSpotUtk = () => {
+      const cookies = (document.cookie || '').split(';');
+      const entry = cookies.find(cookie => cookie.trim().startsWith('hubspotutk='));
+      if (!entry) {
+        return undefined;
+      }
+
+      const value = entry.trim().slice('hubspotutk='.length);
+      try {
+        return decodeURIComponent(value);
+      } catch (err) {
+        console.warn('Failed to decode hubspotutk cookie', err);
+        return undefined;
+      }
+    };
+
     const sendToHubSpot = async (participant, riskLevelText) => {
       const url = 'https://api.hsforms.com/submissions/v3/integration/submit/1959814/4861c8c2-4019-4bd8-9a4c-b1218c87d392';
 
@@ -852,6 +869,11 @@
           pageName: document.title
         }
       };
+
+      const hubSpotUtk = getHubSpotUtk();
+      if (hubSpotUtk) {
+        payload.context.hutk = hubSpotUtk;
+      }
 
       try {
         const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- add a helper to read and decode the hubspotutk cookie in each deployment variant
- include the hutk value in HubSpot submission payload context when available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc44bd609c8324a6dd852b5f4af3ed