### PR TITLE
Harden HubSpot cookie helper

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -29,6 +29,25 @@
       }
     });
 
+    const getHubSpotUtk = () => {
+      if (typeof document === 'undefined' || typeof document.cookie !== 'string') {
+        return undefined;
+      }
+
+      const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]+)/);
+      if (!match || !match[1]) {
+        return undefined;
+      }
+
+      const rawValue = match[1];
+      try {
+        return decodeURIComponent(rawValue);
+      } catch (err) {
+        console.warn('Failed to decode hubspotutk cookie', err);
+        return rawValue;
+      }
+    };
+
     const sendToHubSpot = async (participant, riskLevelText) => {
       const url = 'https://api.hsforms.com/submissions/v3/integration/submit/1959814/4861c8c2-4019-4bd8-9a4c-b1218c87d392';
 
@@ -45,6 +64,11 @@
           pageName: document.title
         }
       };
+
+      const hubSpotUtk = getHubSpotUtk();
+      if (hubSpotUtk) {
+        payload.context.hutk = hubSpotUtk;
+      }
 
       try {
         const response = await fetch(url, {

--- a/wordpress.html
+++ b/wordpress.html
@@ -1164,6 +1164,26 @@
     };
 
     checkFormCompletion();
+
+    const getHubSpotUtk = () => {
+      if (typeof document === 'undefined' || typeof document.cookie !== 'string') {
+        return undefined;
+      }
+
+      const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]+)/);
+      if (!match || !match[1]) {
+        return undefined;
+      }
+
+      const rawValue = match[1];
+      try {
+        return decodeURIComponent(rawValue);
+      } catch (err) {
+        console.warn('Failed to decode hubspotutk cookie', err);
+        return rawValue;
+      }
+    };
+
     const sendToHubSpot = async (participant, riskLevelText, pdfAttachment) => {
       const url = 'https://api.hsforms.com/submissions/v3/integration/submit/1959814/4861c8c2-4019-4bd8-9a4c-b1218c87d392';
 
@@ -1180,6 +1200,11 @@
           pageName: document.title
         }
       };
+
+      const hubSpotUtk = getHubSpotUtk();
+      if (hubSpotUtk) {
+        payload.context.hutk = hubSpotUtk;
+      }
 
       if (pdfAttachment && pdfAttachment.base64) {
         payload.files = [

--- a/wpBackup.html
+++ b/wpBackup.html
@@ -836,6 +836,26 @@
     });
 
     checkFormCompletion();
+
+    const getHubSpotUtk = () => {
+      if (typeof document === 'undefined' || typeof document.cookie !== 'string') {
+        return undefined;
+      }
+
+      const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]+)/);
+      if (!match || !match[1]) {
+        return undefined;
+      }
+
+      const rawValue = match[1];
+      try {
+        return decodeURIComponent(rawValue);
+      } catch (err) {
+        console.warn('Failed to decode hubspotutk cookie', err);
+        return rawValue;
+      }
+    };
+
     const sendToHubSpot = async (participant, riskLevelText) => {
       const url = 'https://api.hsforms.com/submissions/v3/integration/submit/1959814/4861c8c2-4019-4bd8-9a4c-b1218c87d392';
 
@@ -852,6 +872,11 @@
           pageName: document.title
         }
       };
+
+      const hubSpotUtk = getHubSpotUtk();
+      if (hubSpotUtk) {
+        payload.context.hutk = hubSpotUtk;
+      }
 
       try {
         const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- harden the HubSpot cookie reader to guard against missing document.cookie
- fall back to the raw cookie value when decoding fails so the hutk context is still populated
- mirror the resilient helper across the standard and WordPress deployment variants

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc44bd609c8324a6dd852b5f4af3ed