### PR TITLE
Adjust HubSpot cookie helper fallback

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -29,6 +29,23 @@
       }
     });
 
+    const getHubSpotUtk = () => {
+      if (typeof document === 'undefined' || typeof document.cookie !== 'string') {
+        return undefined;
+      }
+
+      const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]+)/);
+      if (!match || !match[1]) {
+        return undefined;
+      }
+
+      try {
+        return decodeURIComponent(match[1]);
+      } catch (err) {
+        return undefined;
+      }
+    };
+
     const sendToHubSpot = async (participant, riskLevelText) => {
       const url = 'https://api.hsforms.com/submissions/v3/integration/submit/1959814/4861c8c2-4019-4bd8-9a4c-b1218c87d392';
 
@@ -45,6 +62,11 @@
           pageName: document.title
         }
       };
+
+      const hubSpotUtk = getHubSpotUtk();
+      if (hubSpotUtk) {
+        payload.context.hutk = hubSpotUtk;
+      }
 
       try {
         const response = await fetch(url, {

--- a/wordpress.html
+++ b/wordpress.html
@@ -1164,6 +1164,24 @@
     };
 
     checkFormCompletion();
+
+    const getHubSpotUtk = () => {
+      if (typeof document === 'undefined' || typeof document.cookie !== 'string') {
+        return undefined;
+      }
+
+      const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]+)/);
+      if (!match || !match[1]) {
+        return undefined;
+      }
+
+      try {
+        return decodeURIComponent(match[1]);
+      } catch (err) {
+        return undefined;
+      }
+    };
+
     const sendToHubSpot = async (participant, riskLevelText, pdfAttachment) => {
       const url = 'https://api.hsforms.com/submissions/v3/integration/submit/1959814/4861c8c2-4019-4bd8-9a4c-b1218c87d392';
 
@@ -1180,6 +1198,11 @@
           pageName: document.title
         }
       };
+
+      const hubSpotUtk = getHubSpotUtk();
+      if (hubSpotUtk) {
+        payload.context.hutk = hubSpotUtk;
+      }
 
       if (pdfAttachment && pdfAttachment.base64) {
         payload.files = [

--- a/wpBackup.html
+++ b/wpBackup.html
@@ -836,6 +836,24 @@
     });
 
     checkFormCompletion();
+
+    const getHubSpotUtk = () => {
+      if (typeof document === 'undefined' || typeof document.cookie !== 'string') {
+        return undefined;
+      }
+
+      const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]+)/);
+      if (!match || !match[1]) {
+        return undefined;
+      }
+
+      try {
+        return decodeURIComponent(match[1]);
+      } catch (err) {
+        return undefined;
+      }
+    };
+
     const sendToHubSpot = async (participant, riskLevelText) => {
       const url = 'https://api.hsforms.com/submissions/v3/integration/submit/1959814/4861c8c2-4019-4bd8-9a4c-b1218c87d392';
 
@@ -852,6 +870,11 @@
           pageName: document.title
         }
       };
+
+      const hubSpotUtk = getHubSpotUtk();
+      if (hubSpotUtk) {
+        payload.context.hutk = hubSpotUtk;
+      }
 
       try {
         const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- update the HubSpot cookie helper to return undefined if decoding fails instead of using the raw value
- apply the same adjustment in the standard script and both WordPress deployment variants to keep them aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc44bd609c8324a6dd852b5f4af3ed