### PR TITLE
Define HubSpot field builder to fix console syntax error

### DIFF
--- a/wpBackup.html
+++ b/wpBackup.html
@@ -837,7 +837,18 @@
 
     checkFormCompletion();
 
+    const buildHubSpotFields = (participant, riskLevelText) => {
+      const rawFields = [
+        { name: 'firstname', value: participant.firstName },
+        { name: 'lastname', value: participant.lastName },
+        { name: 'email', value: participant.email },
+        { name: 'clubname', value: participant.clubName },
+        { name: 'risk_level', value: riskLevelText }
+      ];
 
+      return rawFields
+        .filter(field => typeof field.value === 'string' && field.value.trim() !== '')
+        .map(field => ({
           name: field.name,
           value: field.value.trim()
         }));


### PR DESCRIPTION
## Summary
- add the missing buildHubSpotFields helper so HubSpot submissions build a valid payload
- resolve the inline script syntax error that stopped the assessment logic from running

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4d3407a4832496a18d83f368ff2f