### PR TITLE
Add HubSpot company field to submissions

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -50,6 +50,7 @@
         { name: 'lastname', value: participant.lastName, objectTypeId: '0-1' },
         { name: 'email', value: participant.email, objectTypeId: '0-1' },
         { name: HUBSPOT_CLUB_FIELD, value: participant.clubName, objectTypeId: '0-1' },
+        { name: 'name', value: participant.clubName, objectTypeId: '0-2' },
         { name: HUBSPOT_RISK_LEVEL_FIELD, value: riskLevelText, objectTypeId: '0-1' }
       ];
 

--- a/wordpress.html
+++ b/wordpress.html
@@ -1184,6 +1184,7 @@
         { name: 'lastname', value: participant.lastName, objectTypeId: '0-1' },
         { name: 'email', value: participant.email, objectTypeId: '0-1' },
         { name: HUBSPOT_CLUB_FIELD, value: participant.clubName, objectTypeId: '0-1' },
+        { name: 'name', value: participant.clubName, objectTypeId: '0-2' },
         { name: HUBSPOT_RISK_LEVEL_FIELD, value: riskLevelText, objectTypeId: '0-1' }
       ];
 

--- a/wpBackend.html
+++ b/wpBackend.html
@@ -1183,6 +1183,7 @@
         { name: 'lastname', value: participant.lastName, objectTypeId: HUBSPOT_DEFAULT_OBJECT_TYPE_ID },
         { name: 'email', value: participant.email, objectTypeId: HUBSPOT_DEFAULT_OBJECT_TYPE_ID },
         { name: HUBSPOT_CLUB_FIELD, value: participant.clubName, objectTypeId: HUBSPOT_DEFAULT_OBJECT_TYPE_ID },
+        { name: 'name', value: participant.clubName, objectTypeId: '0-2' },
         { name: HUBSPOT_RISK_LEVEL_FIELD, value: riskLevelText, objectTypeId: HUBSPOT_DEFAULT_OBJECT_TYPE_ID }
       ];
 


### PR DESCRIPTION
## Summary
- add the HubSpot company object "name" field to the shared buildHubSpotFields helper
- mirror the same HubSpot payload change in the WordPress front-end and backend copies of the script

## Testing
- not run (manual verification required)


------
https://chatgpt.com/codex/tasks/task_e_68dd5cf68c248324be26ce38c6bcf926