### PR TITLE
Update HubSpot results PDF property name

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -11,7 +11,7 @@
 
     const HUBSPOT_CLUB_FIELD = 'club_name';
     const HUBSPOT_RISK_LEVEL_FIELD = 'it_assessment_risk_level';
-    const HUBSPOT_RESULTS_PDF_FIELD = 'it_assessment_results_pdf';
+    const HUBSPOT_RESULTS_PDF_FIELD = 'asssessment_results';
 
     const captureParticipant = () => ({
       firstName: document.getElementById('firstName').value.trim(),

--- a/wordpress.html
+++ b/wordpress.html
@@ -833,7 +833,7 @@
 
     const HUBSPOT_CLUB_FIELD = 'club_name';
     const HUBSPOT_RISK_LEVEL_FIELD = 'it_assessment_risk_level';
-    const HUBSPOT_RESULTS_PDF_FIELD = 'it_assessment_results_pdf';
+    const HUBSPOT_RESULTS_PDF_FIELD = 'asssessment_results';
     const PDF_TEMPLATE_URL = 'https://pearlsolves.com/wp-content/uploads/2025/09/Golf-Assessment-Results-Background-.pdf';
     const RESULTS_PDF_FILE_NAME = 'Golf-Club-Security-Assessment-Results.pdf';
 

--- a/wpBackend.html
+++ b/wpBackend.html
@@ -833,7 +833,7 @@
 
     const HUBSPOT_CLUB_FIELD = 'club_name';
     const HUBSPOT_RISK_LEVEL_FIELD = 'it_assessment_risk_level';
-    const HUBSPOT_RESULTS_PDF_FIELD = 'it_assessment_results_pdf';
+    const HUBSPOT_RESULTS_PDF_FIELD = 'asssessment_results';
     const HUBSPOT_DEFAULT_OBJECT_TYPE_ID = '0-1';
     const PDF_TEMPLATE_URL = 'https://pearlsolves.com/wp-content/uploads/2025/09/Golf-Assessment-Results-Background-.pdf';
     const RESULTS_PDF_FILE_NAME = 'Golf-Club-Security-Assessment-Results.pdf';

--- a/wpBackup.html
+++ b/wpBackup.html
@@ -817,7 +817,7 @@
 
     const HUBSPOT_CLUB_FIELD = 'club_name';
     const HUBSPOT_RISK_LEVEL_FIELD = 'it_assessment_risk_level';
-    const HUBSPOT_RESULTS_PDF_FIELD = 'it_assessment_results_pdf';
+    const HUBSPOT_RESULTS_PDF_FIELD = 'asssessment_results';
 
     const captureParticipant = () => ({
       firstName: document.getElementById('firstName').value.trim(),


### PR DESCRIPTION
## Summary
- update the HubSpot results PDF field constant to use the new `asssessment_results` property in each build
- confirm the HubSpot submission payloads continue to reference the shared constant when attaching the generated PDF

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd6a982cc08324b9ba91d9ce2addcf