### PR TITLE
Update HubSpot company club field mapping

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -10,6 +10,7 @@
     ];
 
     const HUBSPOT_CLUB_FIELD = 'club_name';
+    const HUBSPOT_COMPANY_CLUB_FIELD = 'clubname';
     const HUBSPOT_RISK_LEVEL_FIELD = 'it_assessment_risk_level';
     const HUBSPOT_RESULTS_PDF_FIELD = 'asssessment_results';
 
@@ -50,7 +51,7 @@
         { name: 'lastname', value: participant.lastName, objectTypeId: '0-1' },
         { name: 'email', value: participant.email, objectTypeId: '0-1' },
         { name: HUBSPOT_CLUB_FIELD, value: participant.clubName, objectTypeId: '0-1' },
-        { name: 'name', value: participant.clubName, objectTypeId: '0-2' },
+        { name: HUBSPOT_COMPANY_CLUB_FIELD, value: participant.clubName, objectTypeId: '0-2' },
         { name: HUBSPOT_RISK_LEVEL_FIELD, value: riskLevelText, objectTypeId: '0-1' }
       ];
 

--- a/wordpress.html
+++ b/wordpress.html
@@ -832,6 +832,7 @@
     ];
 
     const HUBSPOT_CLUB_FIELD = 'club_name';
+    const HUBSPOT_COMPANY_CLUB_FIELD = 'clubname';
     const HUBSPOT_RISK_LEVEL_FIELD = 'it_assessment_risk_level';
     const HUBSPOT_RESULTS_PDF_FIELD = 'asssessment_results';
     const PDF_TEMPLATE_URL = 'https://pearlsolves.com/wp-content/uploads/2025/09/Golf-Assessment-Results-Background-.pdf';
@@ -1184,7 +1185,7 @@
         { name: 'lastname', value: participant.lastName, objectTypeId: '0-1' },
         { name: 'email', value: participant.email, objectTypeId: '0-1' },
         { name: HUBSPOT_CLUB_FIELD, value: participant.clubName, objectTypeId: '0-1' },
-        { name: 'name', value: participant.clubName, objectTypeId: '0-2' },
+        { name: HUBSPOT_COMPANY_CLUB_FIELD, value: participant.clubName, objectTypeId: '0-2' },
         { name: HUBSPOT_RISK_LEVEL_FIELD, value: riskLevelText, objectTypeId: '0-1' }
       ];
 

--- a/wpBackend.html
+++ b/wpBackend.html
@@ -832,6 +832,7 @@
     ];
 
     const HUBSPOT_CLUB_FIELD = 'club_name';
+    const HUBSPOT_COMPANY_CLUB_FIELD = 'clubname';
     const HUBSPOT_RISK_LEVEL_FIELD = 'it_assessment_risk_level';
     const HUBSPOT_RESULTS_PDF_FIELD = 'asssessment_results';
     const HUBSPOT_DEFAULT_OBJECT_TYPE_ID = '0-1';
@@ -1183,7 +1184,7 @@
         { name: 'lastname', value: participant.lastName, objectTypeId: HUBSPOT_DEFAULT_OBJECT_TYPE_ID },
         { name: 'email', value: participant.email, objectTypeId: HUBSPOT_DEFAULT_OBJECT_TYPE_ID },
         { name: HUBSPOT_CLUB_FIELD, value: participant.clubName, objectTypeId: HUBSPOT_DEFAULT_OBJECT_TYPE_ID },
-        { name: 'name', value: participant.clubName, objectTypeId: '0-2' },
+        { name: HUBSPOT_COMPANY_CLUB_FIELD, value: participant.clubName, objectTypeId: '0-2' },
         { name: HUBSPOT_RISK_LEVEL_FIELD, value: riskLevelText, objectTypeId: HUBSPOT_DEFAULT_OBJECT_TYPE_ID }
       ];
 


### PR DESCRIPTION
## Summary
- introduce a dedicated constant for the HubSpot company club name property in each delivery variant
- map the captured club name to the `clubname` company property instead of the generic `name` field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6f28417c8324bd4c3a96013bd9f1