### PR TITLE
Map club name to HubSpot company field in backend

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -54,6 +54,10 @@
         { name: HUBSPOT_RISK_LEVEL_FIELD, value: riskLevelText, objectTypeId: '0-1' }
       ];
 
+      if (typeof participant.name === 'string' && participant.name.trim() !== '') {
+        rawFields.push({ name: HUBSPOT_CLUB_FIELD, value: participant.name, objectTypeId: '0-2' });
+      }
+
       return rawFields
         .filter(field => typeof field.value === 'string' && field.value.trim() !== '')
         .map(field => ({

--- a/wpBackend.html
+++ b/wpBackend.html
@@ -836,6 +836,7 @@
     const HUBSPOT_RISK_LEVEL_FIELD = 'it_assessment_risk_level';
     const HUBSPOT_RESULTS_PDF_FIELD = 'asssessment_results';
     const HUBSPOT_DEFAULT_OBJECT_TYPE_ID = '0-1';
+    const HUBSPOT_COMPANY_OBJECT_TYPE_ID = '0-2';
     const PDF_TEMPLATE_URL = 'https://pearlsolves.com/wp-content/uploads/2025/09/Golf-Assessment-Results-Background-.pdf';
     const RESULTS_PDF_FILE_NAME = 'Golf-Club-Security-Assessment-Results.pdf';
 
@@ -1186,6 +1187,14 @@
 
         { name: HUBSPOT_RISK_LEVEL_FIELD, value: riskLevelText, objectTypeId: HUBSPOT_DEFAULT_OBJECT_TYPE_ID }
       ];
+
+      if (participant.name && participant.name.trim() !== '') {
+        rawFields.push({
+          name: HUBSPOT_CLUB_FIELD,
+          value: participant.name,
+          objectTypeId: HUBSPOT_COMPANY_OBJECT_TYPE_ID
+        });
+      }
 
       return rawFields
         .filter(field => typeof field.value === 'string' && field.value.trim() !== '')


### PR DESCRIPTION
## Summary
- ensure the HubSpot field builder includes the club name when present using the company object type
- preserve the existing filtering so blank values are skipped before submission
- update the WordPress backend assessment page to submit the club field using the company object type

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd77fb27c083248a682244bd6706c6