### PR TITLE
Update HubSpot PDF attachment field schema

### DIFF
--- a/wordpress.html
+++ b/wordpress.html
@@ -1222,10 +1222,10 @@
       if (pdfAttachment && pdfAttachment.base64) {
         payload.files = [
           {
-            name: HUBSPOT_RESULTS_PDF_FIELD,
+            field: HUBSPOT_RESULTS_PDF_FIELD,
             fileName: pdfAttachment.fileName || RESULTS_PDF_FILE_NAME,
             content: pdfAttachment.base64,
-            mimeType: 'application/pdf'
+            type: 'application/pdf'
           }
         ];
       }

--- a/wpBackend.html
+++ b/wpBackend.html
@@ -1262,10 +1262,10 @@
       if (pdfAttachment && pdfAttachment.base64) {
         payload.files = [
           {
-            name: HUBSPOT_RESULTS_PDF_FIELD,
+            field: HUBSPOT_RESULTS_PDF_FIELD,
             fileName: pdfAttachment.fileName || RESULTS_PDF_FILE_NAME,
             content: pdfAttachment.base64,
-            mimeType: 'application/pdf'
+            type: 'application/pdf'
           }
         ];
       }


### PR DESCRIPTION
## Summary
- replace HubSpot file upload payload to use the `field` key expected by the form schema
- rename the MIME type property to `type` to match HubSpot's attachment requirements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9d859fc48324a1a018909255f701