### PR TITLE
Add validation for unanswered questions in backend assessment form

### DIFF
--- a/wpBackend.html
+++ b/wpBackend.html
@@ -1404,11 +1404,30 @@
 
       const formData = new FormData(assessmentForm);
 
+      const totalQuestions = ASSESSMENT_QUESTIONS.length;
       let yesCount = 0;
       let noCount = 0;
       let unsureCount = 0;
       let naCount = 0;
-      const totalQuestions = ASSESSMENT_QUESTIONS.length;
+
+      for (let i = 1; i <= totalQuestions; i += 1) {
+        const radios = document.getElementsByName(`q${i}`);
+        const container = radios[0]?.closest('.question');
+        const selected = document.querySelector(`input[name="q${i}"]:checked`);
+
+        if (!selected) {
+          if (container) {
+            container.style.border = '2px solid #dc3545';
+          }
+          alert(`Please answer Question ${i} before submitting.`);
+          return;
+        }
+
+        if (container) {
+          container.style.border = '4px solid #28a745';
+        }
+      }
+
       let answeredQuestions = 0;
       let applicableQuestions = 0;
 


### PR DESCRIPTION
## Summary
- validate that every question in the WordPress backend assessment has a selected answer before scoring
- provide user feedback by alerting which question is incomplete and highlighting unanswered items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5263763d4832481272acfebd8a042