### PR TITLE
Update PDF template URL to Render service

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -14,7 +14,7 @@
     const HUBSPOT_RISK_LEVEL_FIELD = 'it_assessment_risk_level';
     const HUBSPOT_RESULTS_PDF_FIELD = 'asssessment_results';
 
-    const DEFAULT_TEMPLATE_URL = 'https://pearlsolves.com/wp-content/uploads/2025/09/Golf-Assessment-Results-Background-.pdf';
+    const DEFAULT_TEMPLATE_URL = 'https://keyring-fv5f.onrender.com/api/pdf-template';
 
     const decodeBase64ToUint8Array = base64 => {
       if (typeof base64 !== 'string' || base64.trim() === '') {
@@ -70,9 +70,6 @@
 
       sources.push(...configUrls);
 
-      if (typeof window !== 'undefined' && window.location && window.location.origin !== 'null') {
-        sources.push('/api/pdf-template');
-      }
       sources.push(DEFAULT_TEMPLATE_URL);
 
       const seen = new Set();

--- a/wpBackend.html
+++ b/wpBackend.html
@@ -834,7 +834,7 @@
     const BACKEND_HUBSPOT_UPLOAD_URL = 'https://keyring-fv5f.onrender.com/api/hubspot/pdf-upload';
     const DEFAULT_PDF_PAGE_WIDTH = 612;
     const DEFAULT_PDF_PAGE_HEIGHT = 792;
-    const DEFAULT_TEMPLATE_URL = 'https://pearlsolves.com/wp-content/uploads/2025/09/Golf-Assessment-Results-Background-.pdf';
+    const DEFAULT_TEMPLATE_URL = 'https://keyring-fv5f.onrender.com/api/pdf-template';
     const RESULTS_PDF_FILE_NAME = 'Golf-Club-Security-Assessment-Results.pdf';
 
     let templatePdfBytesCache = null;
@@ -914,10 +914,6 @@
       }
 
       sources.push(...configUrls);
-
-      if (typeof window !== 'undefined' && window.location && window.location.origin && window.location.origin !== 'null') {
-        sources.push('/api/pdf-template');
-      }
 
       sources.push(DEFAULT_TEMPLATE_URL);
 


### PR DESCRIPTION
## Summary
- point the default PDF template URL to the hosted Render endpoint
- remove the fallback use of the relative /api/pdf-template source so remote URL takes priority

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e534565fd88324ac035089cc8dba1c