### PR TITLE
Adjust backend HubSpot submission to use form data

### DIFF
--- a/wpBackend.html
+++ b/wpBackend.html
@@ -1384,20 +1384,18 @@
         return;
       }
 
-      const payload = {
-        first_name: sanitizeSubmissionField(participant.firstName),
-        last_name: sanitizeSubmissionField(participant.lastName),
-        email: sanitizeSubmissionField(participant.email),
-        club_name: sanitizeSubmissionField(participant.name),
-        risk_level: sanitizeSubmissionField(riskLevelText),
-        assessment_pdf_link: pdfUrl
-      };
+      const submissionData = new FormData();
+      submissionData.append('first_name', sanitizeSubmissionField(participant.firstName));
+      submissionData.append('last_name', sanitizeSubmissionField(participant.lastName));
+      submissionData.append('email', sanitizeSubmissionField(participant.email));
+      submissionData.append('club_name', sanitizeSubmissionField(participant.name));
+      submissionData.append('risk_level', sanitizeSubmissionField(riskLevelText));
+      submissionData.append('assessment_pdf_link', pdfUrl);
 
       try {
         const response = await fetch(BACKEND_HUBSPOT_SUBMIT_URL, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
+          body: submissionData
         });
 
         if (!response.ok) {


### PR DESCRIPTION
## Summary
- switch the backend HubSpot submission request to multipart form data to match the FastAPI endpoint
- retain sanitization while appending each required field to the payload

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e571e8e47c83248aa6cd335990e44a