### PR TITLE
Adjust PDF layout spacing and decode ampersands

### DIFF
--- a/assessment.js
+++ b/assessment.js
@@ -393,7 +393,8 @@
 
       const drawLine = ({ text, x = 60, font = regularFont, size = 12, color = rgb(0, 0, 0), lineHeight = 18 }) => {
         ensureSpace(lineHeight);
-        currentPage.drawText(text, {
+        const content = decodeHTMLEntities(text);
+        currentPage.drawText(content, {
           x,
           y: pageHeight - yOffset,
           size,
@@ -405,9 +406,10 @@
 
       const drawCentered = ({ text, font = boldFont, size = 16, color = rgb(0, 0, 0), lineHeight = 24 }) => {
         ensureSpace(lineHeight);
-        const textWidth = font.widthOfTextAtSize(text, size);
+        const content = decodeHTMLEntities(text);
+        const textWidth = font.widthOfTextAtSize(content, size);
         const x = (pageWidth - textWidth) / 2;
-        currentPage.drawText(text, {
+        currentPage.drawText(content, {
           x,
           y: pageHeight - yOffset,
           size,
@@ -464,25 +466,25 @@
       drawCentered({ text: `Assessment Date: ${snapshot.today}`, font: regularFont, size: 12, lineHeight: 18 });
 
       yOffset += 10;
-      drawLine({ text: `Prepared For: ${snapshot.participant.firstName} ${snapshot.participant.lastName}` });
-      drawLine({ text: `Email: ${snapshot.participant.email}` });
-      drawLine({ text: `Club / Organization: ${snapshot.participant.name}` });
+      drawLine({ text: `Prepared For: ${snapshot.participant.firstName} ${snapshot.participant.lastName}`, lineHeight: 22 });
+      drawLine({ text: `Email: ${snapshot.participant.email}`, lineHeight: 22 });
+      drawLine({ text: `Club / Organization: ${snapshot.participant.name}`, lineHeight: 22 });
 
-      yOffset += 10;
+      yOffset += 16;
       drawLine({
         text: `Risk Level: ${snapshot.riskLevelText}`,
         font: boldFont,
         size: 16,
         color: riskColors[snapshot.riskClass] || rgb(0, 0, 0),
-        lineHeight: 24
+        lineHeight: 28
       });
 
-      yOffset += 10;
-      drawLine({ text: 'Initial Assessment Summary:', font: boldFont, size: 14, lineHeight: 22 });
-      drawLine({ text: `Yes Answers: ${snapshot.yesCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
-      drawLine({ text: `No Answers: ${snapshot.noCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
-      drawLine({ text: `Unsure Answers: ${snapshot.unsureCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
-      drawLine({ text: `Not Applicable: ${snapshot.naCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
+      yOffset += 16;
+      drawLine({ text: 'Initial Assessment Summary:', font: boldFont, size: 14, lineHeight: 24 });
+      drawLine({ text: `Yes Answers: ${snapshot.yesCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80, lineHeight: 20 });
+      drawLine({ text: `No Answers: ${snapshot.noCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80, lineHeight: 20 });
+      drawLine({ text: `Unsure Answers: ${snapshot.unsureCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80, lineHeight: 20 });
+      drawLine({ text: `Not Applicable: ${snapshot.naCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80, lineHeight: 20 });
 
       currentPage = addPageWithTemplate();
       yOffset = topMargin;

--- a/index.html
+++ b/index.html
@@ -1091,6 +1091,18 @@
                     na: rgb(23 / 255, 162 / 255, 184 / 255)
                 };
 
+                const decodeHTMLEntities = (() => {
+                    const textarea = document.createElement('textarea');
+                    return text => {
+                        if (typeof text !== 'string') {
+                            return '';
+                        }
+
+                        textarea.innerHTML = text;
+                        return textarea.value;
+                    };
+                })();
+
                 const ensureSpace = (lineHeight = 18) => {
                     if (yOffset + lineHeight > pageHeight - bottomMargin) {
                         currentPage = addPageWithTemplate();
@@ -1100,7 +1112,8 @@
 
                 const drawLine = ({ text, x = 60, font = regularFont, size = 12, color = rgb(0, 0, 0), lineHeight = 18 }) => {
                     ensureSpace(lineHeight);
-                    currentPage.drawText(text, {
+                    const content = decodeHTMLEntities(text);
+                    currentPage.drawText(content, {
                         x,
                         y: pageHeight - yOffset,
                         size,
@@ -1112,9 +1125,10 @@
 
                 const drawCentered = ({ text, font = boldFont, size = 16, color = rgb(0, 0, 0), lineHeight = 24 }) => {
                     ensureSpace(lineHeight);
-                    const textWidth = font.widthOfTextAtSize(text, size);
+                    const content = decodeHTMLEntities(text);
+                    const textWidth = font.widthOfTextAtSize(content, size);
                     const x = (pageWidth - textWidth) / 2;
-                    currentPage.drawText(text, {
+                    currentPage.drawText(content, {
                         x,
                         y: pageHeight - yOffset,
                         size,
@@ -1171,25 +1185,25 @@
                 drawCentered({ text: `Assessment Date: ${today}`, font: regularFont, size: 12, lineHeight: 18 });
 
                 yOffset += 10;
-                drawLine({ text: `Prepared For: ${participant.firstName} ${participant.lastName}` });
-                drawLine({ text: `Email: ${participant.email}` });
-                drawLine({ text: `Club / Organization: ${participant.name}` });
+                drawLine({ text: `Prepared For: ${participant.firstName} ${participant.lastName}`, lineHeight: 22 });
+                drawLine({ text: `Email: ${participant.email}`, lineHeight: 22 });
+                drawLine({ text: `Club / Organization: ${participant.name}`, lineHeight: 22 });
 
-                yOffset += 10;
+                yOffset += 16;
                 drawLine({
                     text: `Risk Level: ${riskLevelText}`,
                     font: boldFont,
                     size: 16,
                     color: riskColors[riskClass] || rgb(0, 0, 0),
-                    lineHeight: 24
+                    lineHeight: 28
                 });
 
-                yOffset += 10;
-                drawLine({ text: 'Initial Assessment Summary:', font: boldFont, size: 14, lineHeight: 22 });
-                drawLine({ text: `Yes Answers: ${yesCount}/${questions.length}`, x: 80 });
-                drawLine({ text: `No Answers: ${noCount}/${questions.length}`, x: 80 });
-                drawLine({ text: `Unsure Answers: ${unsureCount}/${questions.length}`, x: 80 });
-                drawLine({ text: `Not Applicable: ${naCount}/${questions.length}`, x: 80 });
+                yOffset += 16;
+                drawLine({ text: 'Initial Assessment Summary:', font: boldFont, size: 14, lineHeight: 24 });
+                drawLine({ text: `Yes Answers: ${yesCount}/${questions.length}`, x: 80, lineHeight: 20 });
+                drawLine({ text: `No Answers: ${noCount}/${questions.length}`, x: 80, lineHeight: 20 });
+                drawLine({ text: `Unsure Answers: ${unsureCount}/${questions.length}`, x: 80, lineHeight: 20 });
+                drawLine({ text: `Not Applicable: ${naCount}/${questions.length}`, x: 80, lineHeight: 20 });
 
                 currentPage = addPageWithTemplate();
                 yOffset = topMargin;

--- a/wpBackend.html
+++ b/wpBackend.html
@@ -1198,7 +1198,8 @@
 
       const drawLine = ({ text, x = 60, font = regularFont, size = 12, color = rgb(0, 0, 0), lineHeight = 18 }) => {
         ensureSpace(lineHeight);
-        currentPage.drawText(text, {
+        const content = decodeHTMLEntities(text);
+        currentPage.drawText(content, {
           x,
           y: pageHeight - yOffset,
           size,
@@ -1210,9 +1211,10 @@
 
       const drawCentered = ({ text, font = boldFont, size = 16, color = rgb(0, 0, 0), lineHeight = 24 }) => {
         ensureSpace(lineHeight);
-        const textWidth = font.widthOfTextAtSize(text, size);
+        const content = decodeHTMLEntities(text);
+        const textWidth = font.widthOfTextAtSize(content, size);
         const x = (pageWidth - textWidth) / 2;
-        currentPage.drawText(text, {
+        currentPage.drawText(content, {
           x,
           y: pageHeight - yOffset,
           size,
@@ -1269,25 +1271,25 @@
       drawCentered({ text: `Assessment Date: ${snapshot.today}`, font: regularFont, size: 12, lineHeight: 18 });
 
       yOffset += 10;
-      drawLine({ text: `Prepared For: ${snapshot.participant.firstName} ${snapshot.participant.lastName}` });
-      drawLine({ text: `Email: ${snapshot.participant.email}` });
-      drawLine({ text: `Club / Organization: ${snapshot.participant.name}` });
+      drawLine({ text: `Prepared For: ${snapshot.participant.firstName} ${snapshot.participant.lastName}`, lineHeight: 22 });
+      drawLine({ text: `Email: ${snapshot.participant.email}`, lineHeight: 22 });
+      drawLine({ text: `Club / Organization: ${snapshot.participant.name}`, lineHeight: 22 });
 
-      yOffset += 10;
+      yOffset += 16;
       drawLine({
         text: `Risk Level: ${snapshot.riskLevelText}`,
         font: boldFont,
         size: 16,
         color: riskColors[snapshot.riskClass] || rgb(0, 0, 0),
-        lineHeight: 24
+        lineHeight: 28
       });
 
-      yOffset += 10;
-      drawLine({ text: 'Initial Assessment Summary:', font: boldFont, size: 14, lineHeight: 22 });
-      drawLine({ text: `Yes Answers: ${snapshot.yesCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
-      drawLine({ text: `No Answers: ${snapshot.noCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
-      drawLine({ text: `Unsure Answers: ${snapshot.unsureCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
-      drawLine({ text: `Not Applicable: ${snapshot.naCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80 });
+      yOffset += 16;
+      drawLine({ text: 'Initial Assessment Summary:', font: boldFont, size: 14, lineHeight: 24 });
+      drawLine({ text: `Yes Answers: ${snapshot.yesCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80, lineHeight: 20 });
+      drawLine({ text: `No Answers: ${snapshot.noCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80, lineHeight: 20 });
+      drawLine({ text: `Unsure Answers: ${snapshot.unsureCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80, lineHeight: 20 });
+      drawLine({ text: `Not Applicable: ${snapshot.naCount}/${ASSESSMENT_QUESTIONS.length}`, x: 80, lineHeight: 20 });
 
       currentPage = addPageWithTemplate();
       yOffset = topMargin;


### PR DESCRIPTION
## Summary
- increase spacing between the participant details, risk level, and summary blocks on the generated PDF's first page
- decode HTML entities before drawing centered and line text so titles render ampersands correctly
- mirror the updates across the standalone script, embedded index page, and WordPress backend version to keep the generators consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6c6f057348324bc446f4604bb8234